### PR TITLE
Fix context from class to instance on which rule be applied

### DIFF
--- a/lib/macrow.rb
+++ b/lib/macrow.rb
@@ -29,7 +29,7 @@ class Macrow
       define_method "apply_rule_for_#{keyword}!" do |str, object|
         if str.include? replace_string(keyword)
           begin
-            str.gsub!(replace_string(keyword), block.call(object).to_s)
+            str.gsub!(replace_string(keyword), instance_exec(object, &block).to_s)
             str
           rescue NoMethodError => e
             fail Macrow::ReplaceError, "NoMethodError is raised on applying rule: '#{keyword}'. Please check your rule. Error message is '#{e.message}'"


### PR DESCRIPTION
```ruby
class SomeMacro < Macro
  rules do
    rule 'test' do |arg|
      do_test(arg) # => Undefined method
    end
  end

  private

  def do_test(arg)
    @done = true
  end
end
```

I think we'd like to apply rule on instance context.